### PR TITLE
Fix issue introduced by 05e3289

### DIFF
--- a/samples/nat/nat.c
+++ b/samples/nat/nat.c
@@ -60,7 +60,7 @@ assign_port(mctx_t mctx, int sock)
 {
 	struct port *w;
 	struct sockaddr_in addr[2];
-	socklen_t len = sizeof(addr) * 2;
+	socklen_t len = sizeof(struct sockaddr_in) * 2;
 
 	/* remove a NAT mapping for this connection */
 	if (mtcp_getpeername(mctx, sock, (struct sockaddr *)&addr, &len,
@@ -137,7 +137,7 @@ translate_addr(mctx_t mctx, int sock, int side, uint64_t events,
 	} else /* if (side == MOS_SIDE_SVR) */ {
 		/* SVR (WAN) ==> CLI (LAN) : DNAT */
 		struct sockaddr_in addr[2];
-		socklen_t len = sizeof(addr) * 2;
+		socklen_t len = sizeof(struct sockaddr_in) * 2;
 
 		if (mtcp_getpeername(mctx, sock, (struct sockaddr *)&addr, &len,
 					MOS_SIDE_BOTH) < 0) {


### PR DESCRIPTION
I had a lot of lines in the NAT like
[translate_addr: 144] mtcp_getpeer() failed sock=61 side=1 since that commit.

In nat.c, MOS_SIDE_CLI has been changed by MOS_SIDE_BOTH, without
changing the length of the sockaddr len.
Actually, by luck up to this patch the size of a pointer * 2 was equal
to the size of a sockaddr, but now the error in the sizeof appears.

I suspect this also happens in midstat.c, but I don't have time to push
this further.