### PR TITLE
NAT: Do not check for RSS hash with 1 core

### DIFF
--- a/samples/nat/nat.c
+++ b/samples/nat/nat.c
@@ -70,11 +70,13 @@ assign_port(mctx_t mctx, int sock)
 	}
 	/* assign a port number */
 	pthread_mutex_lock(&g_addrlock);
-	TAILQ_FOREACH(w, &g_free_addrs, link)
-		if (GetRSSCPUCore(g_NATIP, addr[MOS_SIDE_SVR].sin_addr.s_addr,
+	TAILQ_FOREACH(w, &g_free_addrs, link) {
+		/* Don't compute RSS CPU mapping value if # cpus = 1 */
+		if (g_core_limit == 1 || GetRSSCPUCore(g_NATIP, addr[MOS_SIDE_SVR].sin_addr.s_addr,
 				  w->port, addr[MOS_SIDE_SVR].sin_port, g_core_limit)
 			 == mctx->cpu)
 			break;
+	}
 	if (w) {
 		TAILQ_REMOVE(&g_free_addrs, w, link);
 		mtcp_set_uctx(mctx, sock, w);


### PR DESCRIPTION
If the number of cores is 1, then all RSS hash will lead to core 0.