### PR TITLE
Fix compiler error

### DIFF
--- a/samples/common/applib.c
+++ b/samples/common/applib.c
@@ -124,7 +124,7 @@ LoadConfig(char *file_name, struct conf_var *vlist, int size)
 			if ((len = strlen(p)) > CONF_VALUE_LEN)
 				break;
 
-			strncpy(vlist[i].value, p, len);
+			memcpy(vlist[i].value, p, len);
 			vlist[i].value[len] = '\0';
 		}
 	}


### PR DESCRIPTION
Recent GCC (9.3 at least) got smarter and sees that strncopy should not
be used with the length of the string, and memcpy should be used instead. The
error:

In function strncpy,
    inlined from LoadConfig at ../common/applib.c:127:4:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: error: __builtin_strncpy output truncated before terminating nul copying as many bytes from a string as its length [-Werror=stringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../common/applib.c: In function LoadConfig:
../common/applib.c:124:15: note: length computed here
  124 |    if ((len = strlen(p)) > CONF_VALUE_LEN)